### PR TITLE
fix size error

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
     })
 
     upload.on('httpUploadProgress', function (ev) {
-      if (ev.total) currentSize = ev.total
+      currentSize = ev.loaded
     })
 
     util.callbackify(upload.done.bind(upload))(function (err, result) {


### PR DESCRIPTION
Size for files larger than 5MB was returning 0 because total size is unknown due to multipart division at and above 5MB. Setting size to loaded bytes solves this.